### PR TITLE
Feat/track onended

### DIFF
--- a/src/MediaDevicesFake.test.ts
+++ b/src/MediaDevicesFake.test.ts
@@ -4,6 +4,7 @@ import './matchers/dom-exception'
 import './matchers/to-be-uuid'
 import './matchers/to-include-video-track'
 import {MediaDevicesFake} from './MediaDevicesFake'
+import {OpenMediaTracks} from './OpenMediaTracks'
 import {
   allConstraintsFalse,
   noDeviceWithDeviceId,
@@ -54,7 +55,7 @@ const runAndReport = async (fake: MediaDevicesFake, scenario: Scenario) => {
 describe('attach device', () => {
   let fake: MediaDevicesFake
   beforeEach(() => {
-    fake = new MediaDevicesFake(allPermissionsGranted())
+    fake = new MediaDevicesFake(allPermissionsGranted(), new OpenMediaTracks())
   })
 
   describe('attach', () => {
@@ -238,7 +239,7 @@ describe('attach device', () => {
 describe('enumerateDevices', () => {
   describe('still have to ask for device access', () => {
     test('label and deviceId in MediaDeviceInfo is set to empty string', async () => {
-      const fake = new MediaDevicesFake(stillHaveToAskForDeviceAccess())
+      const fake = new MediaDevicesFake(stillHaveToAskForDeviceAccess(), new OpenMediaTracks())
       fake.attach(anyMicrophone({label: 'The microphone', deviceId: 'microphone identifier'}))
       const devices = await fake.enumerateDevices()
       const microphone = devices[0]

--- a/src/MediaDevicesFake.ts
+++ b/src/MediaDevicesFake.ts
@@ -113,6 +113,7 @@ const tryToOpenAStreamFor = (
     initialMediaStreamTrackProperties(selectedDevice.label, trackKind)
   )
   openMediaTracks.track(selectedDevice, mediaTrack)
+  mediaTrack.onTerminated = (track) => openMediaTracks.remove(track)
 
   const mediaTracks = [mediaTrack]
   const mediaStream = new MediaStreamFake(mediaStreamId(), mediaTracks)

--- a/src/MediaStreamTrackFake.test.ts
+++ b/src/MediaStreamTrackFake.test.ts
@@ -92,6 +92,12 @@ describe('MediaStreamTrackFake', () => {
       expect(track.readyState).toBe('ended')
       expect(onEnded).toHaveBeenCalled()
       expect(onEndedListener).toHaveBeenCalled()
+
+      const notCalledA2ndTime = jest.fn()
+      track.onended = notCalledA2ndTime
+
+      control.setPermissionFor('microphone', 'denied')
+      expect(notCalledA2ndTime).not.toHaveBeenCalled()
     })
   })
 

--- a/src/MediaStreamTrackFake.test.ts
+++ b/src/MediaStreamTrackFake.test.ts
@@ -31,11 +31,11 @@ describe('MediaStreamTrackFake', () => {
     expect(track.readyState).toBe('ended')
   })
 
-  test('onEnded is called after stop', () => {
+  test('onEnded is not called after stop', () => {
     const onEndedListener = jest.fn()
     track.onended = onEndedListener
     track.stop()
-    expect(onEndedListener).toHaveBeenCalled()
+    expect(onEndedListener).not.toHaveBeenCalled()
   })
 
   test('return the label', () => {

--- a/src/MediaStreamTrackFake.test.ts
+++ b/src/MediaStreamTrackFake.test.ts
@@ -68,6 +68,25 @@ describe('MediaStreamTrackFake', () => {
       expect(onEnded).toHaveBeenCalled()
       expect(onEndedListener).toHaveBeenCalled()
     })
+    test('when the device permission is revoked', async () => {
+      const device = anyDevice({kind: 'audioinput'})
+      const control = forgeMediaDevices(allAccessAllowed({attachedDevices: [device]}))
+
+      const mediaStream = await control.mediaDevices.getUserMedia({audio: true})
+      const audioTracks = mediaStream.getAudioTracks()
+      const track = audioTracks[0]
+
+      const onEnded = jest.fn()
+      const onEndedListener = jest.fn()
+
+      track.onended = onEnded
+      track.addEventListener('ended', onEndedListener)
+
+      control.setPermissionFor('microphone', 'prompt')
+
+      expect(onEnded).toHaveBeenCalled()
+      expect(onEndedListener).toHaveBeenCalled()
+    })
   })
 
   test('return the label', () => {

--- a/src/MediaStreamTrackFake.test.ts
+++ b/src/MediaStreamTrackFake.test.ts
@@ -55,7 +55,9 @@ describe('MediaStreamTrackFake', () => {
       const track = audioTracks[0]
 
       const onEnded = jest.fn()
-      const onEndedListener = jest.fn()
+      const onEndedListener = jest.fn(() => {
+        expect(track.readyState).toBe('ended')
+      })
       const removedOnEndedListener = jest.fn()
       track.onended = onEnded
       track.addEventListener('ended', onEndedListener)
@@ -64,6 +66,7 @@ describe('MediaStreamTrackFake', () => {
 
       control.remove(device)
 
+      expect(track.readyState).toBe('ended')
       expect(removedOnEndedListener).not.toHaveBeenCalled()
       expect(onEnded).toHaveBeenCalled()
       expect(onEndedListener).toHaveBeenCalled()
@@ -77,7 +80,9 @@ describe('MediaStreamTrackFake', () => {
       const track = audioTracks[0]
 
       const onEnded = jest.fn()
-      const onEndedListener = jest.fn()
+      const onEndedListener = jest.fn(() => {
+        expect(track.readyState).toBe('ended')
+      })
 
       track.onended = onEnded
       track.addEventListener('ended', onEndedListener)

--- a/src/MediaStreamTrackFake.test.ts
+++ b/src/MediaStreamTrackFake.test.ts
@@ -30,6 +30,14 @@ describe('MediaStreamTrackFake', () => {
     track.stop()
     expect(track.readyState).toBe('ended')
   })
+
+  test('onEnded is called after stop', () => {
+    const onEndedListener = jest.fn()
+    track.onended = onEndedListener
+    track.stop()
+    expect(onEndedListener).toHaveBeenCalled()
+  })
+
   test('return the label', () => {
     expect(track.label).toBe('The Label')
   })

--- a/src/MediaStreamTrackFake.test.ts
+++ b/src/MediaStreamTrackFake.test.ts
@@ -46,7 +46,7 @@ describe('MediaStreamTrackFake', () => {
 
   // https://w3c.github.io/mediacapture-main/getusermedia.html#event-mediastreamtrack-ended
   describe('is called', () => {
-    test('when the device is unplugged', async () => {
+    test('when the device is removed', async () => {
       const device = anyDevice({kind: 'audioinput'})
       const control = forgeMediaDevices(allAccessAllowed({attachedDevices: [device]}))
 
@@ -84,6 +84,7 @@ describe('MediaStreamTrackFake', () => {
 
       control.setPermissionFor('microphone', 'prompt')
 
+      expect(track.readyState).toBe('ended')
       expect(onEnded).toHaveBeenCalled()
       expect(onEndedListener).toHaveBeenCalled()
     })

--- a/src/MediaStreamTrackFake.ts
+++ b/src/MediaStreamTrackFake.ts
@@ -34,6 +34,7 @@ export class MediaStreamTrackFake implements MediaStreamTrack {
   }
 
   permissionRevoked() {
+    this.stop()
     this.notifyEndedListeners()
   }
 

--- a/src/MediaStreamTrackFake.ts
+++ b/src/MediaStreamTrackFake.ts
@@ -30,6 +30,7 @@ export class MediaStreamTrackFake implements MediaStreamTrack {
   constructor(private readonly properties: MediaStreamTrackProperties) {}
 
   deviceRemoved() {
+    this.stop()
     this.notifyEndedListeners()
   }
 

--- a/src/MediaStreamTrackFake.ts
+++ b/src/MediaStreamTrackFake.ts
@@ -30,10 +30,11 @@ export class MediaStreamTrackFake implements MediaStreamTrack {
   constructor(private readonly properties: MediaStreamTrackProperties) {}
 
   deviceRemoved() {
-    if (this._onEndedListener) {
-      this._onEndedListener.call(this, new Event('ended'))
-    }
-    this.trackEndedListeners.forEach((listener) => listener.call(this, new Event('ended')))
+    this.notifyEndedListeners()
+  }
+
+  permissionRevoked() {
+    this.notifyEndedListeners()
   }
 
   /**
@@ -250,5 +251,12 @@ export class MediaStreamTrackFake implements MediaStreamTrack {
    */
   stop(): void {
     this.properties.readyState = 'ended'
+  }
+
+  private notifyEndedListeners() {
+    if (this._onEndedListener) {
+      this._onEndedListener.call(this, new Event('ended'))
+    }
+    this.trackEndedListeners.forEach((listener) => listener.call(this, new Event('ended')))
   }
 }

--- a/src/MediaStreamTrackFake.ts
+++ b/src/MediaStreamTrackFake.ts
@@ -225,6 +225,5 @@ export class MediaStreamTrackFake implements MediaStreamTrack {
    */
   stop(): void {
     this.properties.readyState = 'ended'
-    this._onEndedListener?.(new Event('stand-in'))
   }
 }

--- a/src/MediaStreamTrackFake.ts
+++ b/src/MediaStreamTrackFake.ts
@@ -24,6 +24,8 @@ export const initialMediaStreamTrackProperties = (
  * typically, these are audio or video tracks, but other track types may exist as well.
  */
 export class MediaStreamTrackFake implements MediaStreamTrack {
+  private _onEndedListener: MediaStreamTrackEventListener | null = null
+
   constructor(private readonly properties: MediaStreamTrackProperties) {}
 
   /**
@@ -88,12 +90,12 @@ export class MediaStreamTrackFake implements MediaStreamTrack {
     return this.properties.readyState
   }
 
-  set onended(_listener: MediaStreamTrackEventListener | null) {
-    throw notImplemented('set MediaStreamTrackFake.onended')
+  set onended(listener: MediaStreamTrackEventListener | null) {
+    this._onEndedListener = listener
   }
 
   get onended(): MediaStreamTrackEventListener | null {
-    throw notImplemented('get MediaStreamTrackFake.onended')
+    return this._onEndedListener
   }
 
   set onisolationchange(_listener: MediaStreamTrackEventListener | null) {
@@ -223,5 +225,6 @@ export class MediaStreamTrackFake implements MediaStreamTrack {
    */
   stop(): void {
     this.properties.readyState = 'ended'
+    this._onEndedListener?.(new Event('stand-in'))
   }
 }

--- a/src/OpenMediaTracks.ts
+++ b/src/OpenMediaTracks.ts
@@ -4,6 +4,20 @@ import {MediaStreamTrackFake} from './MediaStreamTrackFake'
 
 type Entry = {mediaDevice: MediaDeviceInfoFake; mediaTrack: MediaStreamTrackFake}
 
+function assertUnreachable(_: 'you missed a case'): never {
+  throw new Error("Didn't expect to get here")
+}
+
+function toKind(toRemove: 'camera' | 'microphone'): MediaDeviceKind {
+  if (toRemove === 'camera') {
+    return 'videoinput'
+  }
+  if (toRemove === 'microphone') {
+    return 'audioinput'
+  }
+  assertUnreachable(toRemove)
+}
+
 export class OpenMediaTracks {
   private readonly entries: Entry[] = []
 
@@ -11,7 +25,15 @@ export class OpenMediaTracks {
     this.entries.push({mediaDevice, mediaTrack})
   }
 
-  allFor(toRemove: MediaDeviceDescription): MediaStreamTrackFake[] {
+  allFor(toRemove: MediaDeviceDescription | 'camera' | 'microphone'): MediaStreamTrackFake[] {
+    if (typeof toRemove === 'string') {
+      const kind = toKind(toRemove)
+      return this.entries
+        .filter((entry) => {
+          return entry.mediaDevice.kind === kind
+        })
+        .map((entry) => entry.mediaTrack)
+    }
     return this.entries
       .filter((entry) => {
         const trackedDevice = entry.mediaDevice

--- a/src/OpenMediaTracks.ts
+++ b/src/OpenMediaTracks.ts
@@ -21,8 +21,16 @@ function toKind(toRemove: 'camera' | 'microphone'): MediaDeviceKind {
 export class OpenMediaTracks {
   private readonly entries: Entry[] = []
 
-  track(mediaDevice: MediaDeviceInfoFake, mediaTrack: MediaStreamTrackFake) {
-    this.entries.push({mediaDevice, mediaTrack})
+  track(mediaDevice: MediaDeviceInfoFake, mediaStreamTrack: MediaStreamTrackFake) {
+    this.entries.push({mediaDevice, mediaTrack: mediaStreamTrack})
+  }
+
+  remove(toRemove: MediaStreamTrackFake) {
+    const index = this.entries.findIndex((entry) => entry.mediaTrack === toRemove)
+    if (index === -1) {
+      return
+    }
+    this.entries.splice(index, 1)
   }
 
   allFor(toRemove: MediaDeviceDescription | 'camera' | 'microphone'): MediaStreamTrackFake[] {

--- a/src/OpenMediaTracks.ts
+++ b/src/OpenMediaTracks.ts
@@ -1,0 +1,26 @@
+import {MediaDeviceDescription} from './MediaDeviceDescription'
+import {MediaDeviceInfoFake} from './MediaDeviceInfoFake'
+import {MediaStreamTrackFake} from './MediaStreamTrackFake'
+
+type Entry = {mediaDevice: MediaDeviceInfoFake; mediaTrack: MediaStreamTrackFake}
+
+export class OpenMediaTracks {
+  private readonly entries: Entry[] = []
+
+  track(mediaDevice: MediaDeviceInfoFake, mediaTrack: MediaStreamTrackFake) {
+    this.entries.push({mediaDevice, mediaTrack})
+  }
+
+  allFor(toRemove: MediaDeviceDescription): MediaStreamTrackFake[] {
+    return this.entries
+      .filter((entry) => {
+        const trackedDevice = entry.mediaDevice
+        return (
+          trackedDevice.kind === toRemove.kind &&
+          trackedDevice.groupId === toRemove.groupId &&
+          trackedDevice.deviceId === toRemove.deviceId
+        )
+      })
+      .map((entry) => entry.mediaTrack)
+  }
+}

--- a/src/UserConsentTracker.ts
+++ b/src/UserConsentTracker.ts
@@ -46,10 +46,17 @@ export class UserConsentTracker {
   constructor(readonly _userConsent: UserConsent) {}
 
   permissionStatusFor(kind: keyof UserConsent) {
-    const permissionState = this._userConsent[kind]
+    const permissionState = this.permissionStateFor(kind)
     const permissionStatus = new PermissionStatusFake(permissionState)
     this._trackedPermissionStatus[kind].push(permissionStatus)
     return permissionStatus
+  }
+
+  setPermissionFor(kind: keyof UserConsent, state: PermissionState) {
+    this._userConsent[kind] = state
+    this._trackedPermissionStatus[kind].forEach((permissionStatus) =>
+      permissionStatus.updateTo(state)
+    )
   }
 
   requestPermissionFor(permissionRequest: PermissionRequest) {
@@ -67,6 +74,10 @@ export class UserConsentTracker {
       return
     }
     this._pendingPermissionRequest = permissionRequest
+  }
+
+  private permissionStateFor(kind: 'camera' | 'microphone') {
+    return this._userConsent[kind]
   }
 
   private permissionGrantedFor(deviceKind: MediaDeviceKind) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export {anyMicrophone, anyCamera, anyDevice} from './DeviceMother'
 export {PermissionPrompt, PermissionPromptAction, RequestedMediaInput} from './UserConsentTracker'
 import {MediaDeviceDescription} from './MediaDeviceDescription'
 import {MediaDevicesFake} from './MediaDevicesFake'
+import {OpenMediaTracks} from './OpenMediaTracks'
 import {PermissionsFake} from './permissions/PermissionsFake'
 import {
   allConstraintsFalse,
@@ -66,7 +67,8 @@ export const forgeMediaDevices = (initial: InitialSetup = {}): MediaDevicesContr
   const camera = initial.camera ?? 'prompt'
   const microphone = initial.microphone ?? 'prompt'
   const consentTracker = new UserConsentTracker({camera, microphone})
-  const mediaDevicesFake = new MediaDevicesFake(consentTracker)
+  const openMediaTracks = new OpenMediaTracks()
+  const mediaDevicesFake = new MediaDevicesFake(consentTracker, openMediaTracks)
   const permissionsFake = new PermissionsFake(consentTracker)
   const attachedDevices = initial.attachedDevices ?? []
   attachedDevices.forEach((device) => mediaDevicesFake.attach(device))
@@ -85,6 +87,9 @@ export const forgeMediaDevices = (initial: InitialSetup = {}): MediaDevicesContr
     }
 
     remove(toRemove: MediaDeviceDescription): void {
+      openMediaTracks.allFor(toRemove).forEach((fake) => {
+        fake.deviceRemoved()
+      })
       mediaDevicesFake.remove(toRemove)
     }
 


### PR DESCRIPTION
Removes exception when setting onended listener

- [x] call listeners if device is unplugged
- [x] call listeners if permissions are revoked
- [x] remove tracks from OpenMediaTracks
      - track is stopped
      - media stream is closed
      - device is unplugged